### PR TITLE
Update ADVANCED.md

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -158,7 +158,7 @@ Alternatively, you may clone the github repository and run `pip install .`
 Install the required dependencies:
 
 ```
-sudo yum install python-devel libevent-devel python-pip gcc xz-devel
+sudo yum install python-devel libevent-devel python-pip gcc xz-devel openssl-devel.x86_64
 ```
 
 NOTE: On RHEL and CentOS you will need the


### PR DESCRIPTION
LSB Version:    :base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch
Distributor ID: CentOS
Description:    CentOS release 6.5 (Final)
Release:    6.5
## Codename:   Final
## Docker version 1.9.1, build a34a1d5

[root@10 docker-registry]# pip install .
Processing /root/docker-registry
Requirement already satisfied (use --upgrade to upgrade): docker-registry-core<3,>=2 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): importlib==1.0.3 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): argparse==1.2.1 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): backports.lzma!=0.0.4,==0.0.3 in /usr/lib64/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): blinker==1.3 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): Flask==0.10.1 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): gevent==1.0.1 in /usr/lib64/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): gunicorn==19.1.1 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): PyYAML==3.11 in /usr/lib64/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): requests==2.3.0 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Collecting M2Crypto==0.22.3 (from docker-registry==1.0.0-dev)
  Using cached M2Crypto-0.22.3.tar.gz
Collecting sqlalchemy==0.9.4 (from docker-registry==1.0.0-dev)
  Using cached SQLAlchemy-0.9.4.tar.gz
Requirement already satisfied (use --upgrade to upgrade): setuptools==5.8 in /usr/lib/python2.6/site-packages (from docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): boto==2.34.0 in /usr/lib/python2.6/site-packages (from docker-registry-core<3,>=2->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): redis==2.10.3 in /usr/lib/python2.6/site-packages (from docker-registry-core<3,>=2->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): simplejson==3.6.2 in /usr/lib64/python2.6/site-packages (from docker-registry-core<3,>=2->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): Werkzeug>=0.7 in /usr/lib/python2.6/site-packages (from Flask==0.10.1->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): Jinja2>=2.4 in /usr/lib/python2.6/site-packages (from Flask==0.10.1->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): itsdangerous>=0.21 in /usr/lib/python2.6/site-packages (from Flask==0.10.1->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): greenlet in /usr/lib64/python2.6/site-packages (from gevent==1.0.1->docker-registry==1.0.0-dev)
Requirement already satisfied (use --upgrade to upgrade): MarkupSafe in /usr/lib64/python2.6/site-packages (from Jinja2>=2.4->Flask==0.10.1->docker-registry==1.0.0-dev)
Installing collected packages: M2Crypto, sqlalchemy, docker-registry
  Running setup.py install for M2Crypto
    Complete output from command /usr/bin/python -c "import setuptools, tokenize;**file**='/tmp/pip-build-p7HIw8/M2Crypto/setup.py';exec(compile(getattr(tokenize, 'open', open)(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /tmp/pip-HzWO6Q-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-2.6
    creating build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/BN.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/threading.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/Rand.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/BIO.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/RSA.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/m2xmlrpclib.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/AuthCookie.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/httpslib.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/callback.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/SMIME.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/Engine.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/**init**.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/X509.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/ftpslib.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/Err.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/EVP.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/RC4.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/DH.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/m2urllib.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/m2urllib2.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/ASN1.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/m2.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/DSA.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/EC.py -> build/lib.linux-x86_64-2.6/M2Crypto
    copying M2Crypto/util.py -> build/lib.linux-x86_64-2.6/M2Crypto
    creating build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/Checker.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/Connection.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/cb.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/timeout.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/Cipher.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/**init**.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/SSLServer.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/Session.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/ssl_dispatcher.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/TwistedProtocolWrapper.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    copying M2Crypto/SSL/Context.py -> build/lib.linux-x86_64-2.6/M2Crypto/SSL
    running build_ext
    building 'M2Crypto.**m2crypto' extension
    swigging SWIG/_m2crypto.i to SWIG/_m2crypto_wrap.c
    swig -python -I/usr/include/python2.6 -I/usr/include -I/usr/include/openssl -includeall -modern -D__x86_64** -o SWIG/_m2crypto_wrap.c SWIG/_m2crypto.i
    SWIG/_m2crypto.i:30: Error: Unable to find 'openssl/opensslv.h'
    SWIG/_m2crypto.i:33: Error: Unable to find 'openssl/safestack.h'
    SWIG/_evp.i:12: Error: Unable to find 'openssl/opensslconf.h'
    SWIG/_ec.i:7: Error: Unable to find 'openssl/opensslconf.h'
    error: command 'swig' failed with exit status 1

```
----------------------------------------
```

Command "/usr/bin/python -c "import setuptools, tokenize;**file**='/tmp/pip-build-p7HIw8/M2Crypto/setup.py';exec(compile(getattr(tokenize, 'open', open)(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /tmp/pip-HzWO6Q-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-p7HIw8/M2Crypto
